### PR TITLE
Replace all the dots

### DIFF
--- a/lib/CLI.js
+++ b/lib/CLI.js
@@ -644,7 +644,7 @@ CLI.prototype.remoteHostConfig = function(host, options) {
       if(error) throw error
 
       if(!host) {
-        host = hostname.replace(/\./, '-')
+        host = hostname.replace(/\./g, '-')
       }
 
       console.info('')
@@ -679,7 +679,7 @@ CLI.prototype.addRemoteUser = function(userName, hostName, options) {
       console.info('')
       console.info('Add the following to your bossweb-users file:')
       console.info('')
-      console.info('[%s.%s]'.cyan, userName, os.hostname().replace(/\./, '-'))
+      console.info('[%s.%s]'.cyan, userName, os.hostname().replace(/\./g, '-'))
       console.info('  secret = %s'.cyan, user.secret)
       console.info('')
       console.info('If %s is not in your config file yet, run `bs-web passwd %s` to generate the appropriate configuration', userName, userName)


### PR DESCRIPTION
Simple fix adding global flag to replace all the dots in the hostname
