### PR TITLE
Fixes #23 - Fix exceptions accessing undefined properties or properties of null/undefined values.

### DIFF
--- a/lib/Processes.js
+++ b/lib/Processes.js
@@ -26,17 +26,17 @@ Processes.prototype.list = function(options) {
           return table.addRow(['?', '?', '?', '?', '?', '?', '?', '?', '?', '?', '?', type])
         }
 
-        var pid = proc.pid ? proc.pid : '?',
-          user = proc.user !== undefined ? proc.user : '?',
-          group = proc.group !== undefined ? proc.group : '?',
-          name = proc.name || '?',
-          uptime = proc.uptime ? this._moment.duration(proc.uptime * 1000).humanize() : '?',
-          restarts = proc.restarts !== undefined ? proc.restarts : '?',
-          rss = proc.residentSize && isNaN(proc.residentSize) ? '?' : this._formatMemory(proc.residentSize, true),
-          heapTotal = proc.heapTotal && isNaN(proc.heapTotal) ? '?' : this._formatMemory(proc.heapTotal, true),
-          heapUsed = proc.heapUsed && isNaN(proc.heapUsed) ? '?' : this._formatMemory(proc.heapUsed, true),
-          cpu = proc.cpu && isNaN(proc.cpu) ? '?' : proc.cpu.toFixed(2),
-          status = !proc.status ? '?' : proc.status
+        var pid = proc.pid == null ? '?' : proc.pid,
+          user = proc.user == null ? '?' : proc.user,
+          group = proc.group == null ? '?' : proc.group,
+          name = proc.name == null ? '?' : proc.name,
+          uptime = proc.uptime == null || isNaN(proc.uptime) ? '?' : this._moment.duration(proc.uptime * 1000).humanize(),
+          restarts = proc.restarts == null ? '?' : proc.restarts,
+          rss = proc.residentSize == null || isNaN(proc.residentSize) ? '?' : this._formatMemory(proc.residentSize, true),
+          heapTotal = proc.heapTotal == null || isNaN(proc.heapTotal) ? '?' : this._formatMemory(proc.heapTotal, true),
+          heapUsed = proc.heapUsed == null || isNaN(proc.heapUsed) ? '?' : this._formatMemory(proc.heapUsed, true),
+          cpu = proc.cpu == null || isNaN(proc.cpu) ? '?' : proc.cpu.toFixed(2),
+          status = proc.status == null ? '?' : proc.status
 
         table.addRow([pid, user, group, name, uptime, restarts, cpu, rss, heapTotal, heapUsed, status, type])
       }.bind(this)

--- a/test/lib/ProcessesTest.js
+++ b/test/lib/ProcessesTest.js
@@ -71,6 +71,58 @@ describe('Processes', function() {
     expect(console.info.called).to.be.true
   })
 
+  it('should not throw formatting process list with undefined values', function() {
+    var processList = [{}]
+
+    boss.listProcesses = sinon.stub()
+    boss.listProcesses.withArgs(sinon.match.func).callsArgWith(0, undefined, processList)
+
+    processes.list()
+
+    expect(boss.listProcesses.threw()).to.be.false
+  })
+
+  it('should not throw formatting process list with null values', function() {
+    var processList = [{
+      pid: null,
+      user: null,
+      group: null,
+      name: null,
+      uptime: null,
+      restarts: null,
+      rss: null,
+      heapTotal: null,
+      heapUsed: null,
+      cpu: null,
+      status: null
+    }]
+
+    boss.listProcesses = sinon.stub()
+    boss.listProcesses.withArgs(sinon.match.func).callsArgWith(0, undefined, processList)
+
+    processes.list()
+
+    expect(boss.listProcesses.threw()).to.be.false
+  })
+
+  it('should not throw formatting process list with non-numeric values', function() {
+    // Set properties that require extra numeric formatting to non-numeric objects
+    var processList = [{
+      uptime: 'uptime',
+      rss: 'rss',
+      heapTotal: 'heapTotal',
+      heapUsed: 'heapUsed',
+      cpu: 'cpu'
+    }]
+
+    boss.listProcesses = sinon.stub()
+    boss.listProcesses.withArgs(sinon.match.func).callsArgWith(0, undefined, processList)
+
+    processes.list()
+
+    expect(boss.listProcesses.threw()).to.be.false
+  })
+
   it('should start a process', function() {
     var script = 'script'
     var options = {}


### PR DESCRIPTION
Compare with null because `x == null` is always `false` unless x is `null` or `undefined`. For values that require extra numeric formatting (memory, rounding etc.) there is an extra `isNaN` check.
