### PR TITLE
fix pidOrName compare process name type

### DIFF
--- a/lib/cli/Actions.js
+++ b/lib/cli/Actions.js
@@ -130,7 +130,8 @@ Actions.prototype._withEach = function (pidOrNames, options, withEach, afterAll)
             name = name.substring('Cluster: '.length)
           }
           //pidOrName maybe a number by user input
-          if (name == pidOrName || managedProcess.pid === pidOrName || pidOrName === '*') {
+          //pidOrname maybe -a -something e,g. so i add remove all command.
+          if (name == pidOrName || managedProcess.pid === pidOrName || pidOrName === '*' || pidOrName === 'all') {
             tasks.push(function (managedProcess, callback) {
               withEach(managedProcess, guvnor, function (error) {
                 if (managedProcess && managedProcess.disconnect) {

--- a/lib/cli/Actions.js
+++ b/lib/cli/Actions.js
@@ -129,8 +129,8 @@ Actions.prototype._withEach = function (pidOrNames, options, withEach, afterAll)
             // remove the 'Cluster: ' from the cluster manager's name
             name = name.substring('Cluster: '.length)
           }
-
-          if (name === pidOrName || managedProcess.pid === pidOrName || pidOrName === '*') {
+          //pidOrName maybe a number by user input
+          if (name == pidOrName || managedProcess.pid === pidOrName || pidOrName === '*') {
             tasks.push(function (managedProcess, callback) {
               withEach(managedProcess, guvnor, function (error) {
                 if (managedProcess && managedProcess.disconnect) {


### PR DESCRIPTION
When i start with a number input,i can remove the process.
```
$ guv start 1234
$ guv remove 1234 //can't remove
```
https://github.com/tableflip/guvnor/blob/2dd914c6ed2b7010a297add0750a3b40963e9c63/lib/cli/Actions.js#L133

-------
```
$ guv start -n -a
$ guv remove -a //can't remove
```
so i add remove all for this situation.